### PR TITLE
Added support for Appengine Managed VMs

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -28,8 +28,6 @@ import (
 	"strconv"
 	"strings"
 
-	"appengine"
-
 	"github.com/astaxie/beegae/context"
 	"github.com/astaxie/beegae/session"
 )
@@ -55,28 +53,6 @@ type ControllerComments struct {
 	Params           []map[string]string
 }
 
-// Controller defines some basic http request handler operations, such as
-// http context, template and view, session and xsrf.
-type Controller struct {
-	Ctx            *context.Context
-	Data           map[interface{}]interface{}
-	controllerName string
-	actionName     string
-	TplNames       string
-	Layout         string
-	LayoutSections map[string]string // the key is the section name and the value is the template name
-	TplExt         string
-	_xsrf_token    string
-	gotofunc       string
-	CruSession     session.SessionStore
-	XSRFExpire     int
-	AppController  interface{}
-	AppEngineCtx   appengine.Context
-	EnableRender   bool
-	EnableXSRF     bool
-	methodMapping  map[string]func() //method:routertree
-}
-
 // ControllerInterface is an interface to uniform all controller handler.
 type ControllerInterface interface {
 	Init(ct *context.Context, controllerName, actionName string, app interface{})
@@ -94,22 +70,6 @@ type ControllerInterface interface {
 	CheckXsrfCookie() bool
 	HandlerFunc(fn string) bool
 	URLMapping()
-}
-
-// Init generates default values of controller operations.
-func (c *Controller) Init(ctx *context.Context, controllerName, actionName string, app interface{}) {
-	c.Layout = ""
-	c.TplNames = ""
-	c.controllerName = controllerName
-	c.actionName = actionName
-	c.Ctx = ctx
-	c.TplExt = "tpl"
-	c.AppController = app
-	c.EnableRender = true
-	c.EnableXSRF = true
-	c.Data = ctx.Input.Data
-	c.AppEngineCtx = appengine.NewContext(ctx.Request)
-	c.methodMapping = make(map[string]func())
 }
 
 // Prepare runs after Init before request function execution.

--- a/controller_definition.go
+++ b/controller_definition.go
@@ -1,0 +1,47 @@
+// +build appengine !appenginevm
+
+package beegae
+
+import (
+	"appengine"
+	"github.com/astaxie/beegae/context"
+	"github.com/astaxie/beegae/session"
+)
+
+// Controller defines some basic http request handler operations, such as
+// http context, template and view, session and xsrf.
+type Controller struct {
+	Ctx            *context.Context
+	Data           map[interface{}]interface{}
+	controllerName string
+	actionName     string
+	TplNames       string
+	Layout         string
+	LayoutSections map[string]string // the key is the section name and the value is the template name
+	TplExt         string
+	_xsrf_token    string
+	gotofunc       string
+	CruSession     session.SessionStore
+	XSRFExpire     int
+	AppController  interface{}
+	AppEngineCtx   appengine.Context
+	EnableRender   bool
+	EnableXSRF     bool
+	methodMapping  map[string]func() //method:routertree
+}
+
+// Init generates default values of controller operations.
+func (c *Controller) Init(ctx *context.Context, controllerName, actionName string, app interface{}) {
+	c.Layout = ""
+	c.TplNames = ""
+	c.controllerName = controllerName
+	c.actionName = actionName
+	c.Ctx = ctx
+	c.TplExt = "tpl"
+	c.AppController = app
+	c.EnableRender = true
+	c.EnableXSRF = true
+	c.Data = ctx.Input.Data
+	c.AppEngineCtx = appengine.NewContext(ctx.Request)
+	c.methodMapping = make(map[string]func())
+}

--- a/controller_definition_vm.go
+++ b/controller_definition_vm.go
@@ -1,0 +1,47 @@
+// +build appenginevm !appengine
+
+package beegae
+
+import (
+	"gfithub.com/astaxie/beegae/context"
+	"github.com/astaxie/beegae/session"
+	"google.golang.org/appengine"
+)
+
+// Controller defines some basic http request handler operations, such as
+// http context, template and view, session and xsrf.
+type Controller struct {
+	Ctx            *context.Context
+	Data           map[interface{}]interface{}
+	controllerName string
+	actionName     string
+	TplNames       string
+	Layout         string
+	LayoutSections map[string]string // the key is the section name and the value is the template name
+	TplExt         string
+	_xsrf_token    string
+	gotofunc       string
+	CruSession     session.SessionStore
+	XSRFExpire     int
+	AppController  interface{}
+	AppEngineCtx   appengine.Context
+	EnableRender   bool
+	EnableXSRF     bool
+	methodMapping  map[string]func() //method:routertree
+}
+
+// Init generates default values of controller operations.
+func (c *Controller) Init(ctx *context.Context, controllerName, actionName string, app interface{}) {
+	c.Layout = ""
+	c.TplNames = ""
+	c.controllerName = controllerName
+	c.actionName = actionName
+	c.Ctx = ctx
+	c.TplExt = "tpl"
+	c.AppController = app
+	c.EnableRender = true
+	c.EnableXSRF = true
+	c.Data = ctx.Input.Data
+	c.AppEngineCtx = appengine.NewContext(ctx.Request)
+	c.methodMapping = make(map[string]func())
+}


### PR DESCRIPTION
Appengine Managed VMs import the "appengine" package from a different location.  This means the current beegae code doesn't support managed vms.  Here I've used build constraint tags to put the Controller struct and Init functions into two separate files-- one for appengine, one for appenginevm.  