### PR TITLE
Renamed config.Configcontainer to config.Configer

### DIFF
--- a/config.go
+++ b/config.go
@@ -84,7 +84,7 @@ var (
 )
 
 type beegoAppConfig struct {
-	innerConfig config.ConfigContainer
+	innerConfig config.Configer
 }
 
 func newAppConfig(AppConfigProvider, AppConfigPath string) (*beegoAppConfig, error) {


### PR DESCRIPTION
config.Configcontainer has been renamed in Beego, or doesn't exist from the start. The correct name seems config.Configer.